### PR TITLE
chore: Replace deprecated method to format buffers on NVIM

### DIFF
--- a/plugin/null-ls.rc.lua
+++ b/plugin/null-ls.rc.lua
@@ -21,7 +21,7 @@ null_ls.setup({
         group = augroup_format,
         -- buffer = 0,
         callback = function()
-          vim.lsp.buf.formatting_seq_sync()
+          vim.lsp.buf.format()
         end
       })
     end
@@ -29,4 +29,4 @@ null_ls.setup({
 })
 
 -- Auto commands
-vim.cmd([[ autocmd BufWritePre <buffer> lua vim.lsp.buf.formatting_sync() ]])
+vim.cmd([[ autocmd BufWritePre <buffer> lua vim.lsp.buf.format() ]])


### PR DESCRIPTION
Hello,

Just a little PR to replace deprecated `formatting_seq_sync()` by`format()`. 

This is to remove the annoying warning message that appears every time you save a file =) 

Off-topic: 
BTW, I loved your article on Medium and how you structured the LUA files, nicely done! I'm refactoring mine to organize the house. 🤣

